### PR TITLE
tidy package structure for imports

### DIFF
--- a/pkg/feature/feature.go
+++ b/pkg/feature/feature.go
@@ -1,4 +1,4 @@
-package featureflags
+package feature
 
 type FeatureFlag interface {
 	Name() string


### PR DESCRIPTION
Prevents importing `k8s.io` in external packages that don't require them